### PR TITLE
中間体ArticleJoinRowの削除

### DIFF
--- a/docs/issue/close/006_article-re-design.md
+++ b/docs/issue/close/006_article-re-design.md
@@ -101,9 +101,8 @@ mod.rsとは従属的な関係となる。
 - このArticleUrlStatus追加に伴い、その取得のためのクエリと関数とテストの実装が必要となる
 - 失敗URL抽出や優先度付けの判断材料として `pub_date` を保持する（既存テーブル `article_links.pub_date` の値）
 
-## ArticleJoinRow
-- `ArticleLink`と`Article`のJOIN結果をそのまま受け取るDB用の構造体
-- 外部には公開しない
+## ArticleJoinRow（廃止）
+この中間体は廃止。`search_articles` はDB側で成功行のみを絞り込み、`Article` を直接 `FromRow` で受け取る。
 
 ---
 
@@ -125,8 +124,8 @@ mod.rsとは従属的な関係となる。
   - timestampは`Article`における`update_at`
   - sourceは`Article`には変換されない
 
-## ArticleJoinRowQuery
-- `ArticleJoinRow` を取得する際に使用するクエリモデル
+## ArticleJoinRowQuery（廃止）
+`ArticleJoinRow` 廃止に伴い不要。期間・パターン・件数等の条件は `ArticleQuery` に集約。
 
 ---
 
@@ -142,8 +141,8 @@ mod.rsとは従属的な関係となる。
 
 ---
 
-## search_article_join_rows()
-- `ArticleJoinRowQuery` を受け取り、`Vec<ArticleJoinRow>` を返す関数
+## search_article_join_rows()（廃止）
+低レベルJOINの取得関数は削除。`search_articles` が直接SQLで `Article` を返す。
 
 # 要望
 - 過度な抽象化は控えること

--- a/docs/issue/close/006_article-re-design.md
+++ b/docs/issue/close/006_article-re-design.md
@@ -89,15 +89,17 @@ mod.rsとは従属的な関係となる。
 ---
 
 テーブル定義:
-| Field       | Type        |
-| ----------- | ----------- |
-| url         | String      |
-| status_code | Option<i32> |
+| Field       | Type                  |
+| ----------- | --------------------- |
+| url         | String                |
+| status_code | Option<i32>           |
+| pub_date    | DateTime<Utc>         |
 
 ---
 
 注意点:
 - このArticleUrlStatus追加に伴い、その取得のためのクエリと関数とテストの実装が必要となる
+- 失敗URL抽出や優先度付けの判断材料として `pub_date` を保持する（既存テーブル `article_links.pub_date` の値）
 
 ## ArticleJoinRow
 - `ArticleLink`と`Article`のJOIN結果をそのまま受け取るDB用の構造体

--- a/src/core/article/model.rs
+++ b/src/core/article/model.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 
 // ユーザー側が実際に取り扱う情報モデル（ドメイン向け）
-#[derive(Debug, Clone, Serialize, Deserialize)]
+// 直接SQLから取得できるようにFromRowを付与
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Article {
     pub url: String,
     pub title: String,
@@ -30,18 +31,6 @@ pub struct ArticleUrlStatus {
     pub status_code: Option<i32>,
     // 記事の公開日時。再取得優先度の判断などに用いる（低レベル用途）
     pub pub_date: DateTime<Utc>,
-}
-
-// ArticleLinkとArticleのJOIN結果をそのまま受け取るDB用の構造体
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
-pub(crate) struct ArticleJoinRow {
-    pub url: String,
-    pub title: String,
-    pub pub_date: DateTime<Utc>,
-    pub source: String,
-    pub timestamp: Option<DateTime<Utc>>,
-    pub status_code: Option<i32>,
-    pub content: Option<String>,
 }
 
 // 記事内容の構造体
@@ -233,55 +222,6 @@ mod tests {
             assert!(json.contains("\"url\":\"https://example.com\""));
             assert!(json.contains("\"status_code\":null"));
             assert!(json.contains("\"pub_date\":\"2023-01-01T00:00:00Z\""));
-        }
-    }
-
-    mod article_join_row {
-        use super::*;
-
-        /// ArticleJoinRowの基本構造テスト
-        /// 目的: 構造体の基本的な作成・フィールドアクセスを確認
-        #[test]
-        fn test_article_join_row_creation() {
-            let join_row = ArticleJoinRow {
-                url: "https://example.com".to_string(),
-                title: "Test Article".to_string(),
-                pub_date: Utc.with_ymd_and_hms(2023, 12, 25, 10, 30, 0).unwrap(),
-                source: "RSS".to_string(),
-                timestamp: Some(Utc.with_ymd_and_hms(2023, 12, 26, 10, 30, 0).unwrap()),
-                status_code: Some(200),
-                content: Some("Article content".to_string()),
-            };
-
-            assert_eq!(join_row.url, "https://example.com");
-            assert_eq!(join_row.title, "Test Article");
-            assert_eq!(join_row.source, "RSS");
-            assert_eq!(join_row.status_code, Some(200));
-            assert!(join_row.timestamp.is_some());
-            assert!(join_row.content.is_some());
-        }
-
-        /// ArticleJoinRowのシリアライゼーションテスト
-        /// 目的: JSONへの正常な変換を確認
-        #[test]
-        fn test_article_join_row_serialization() {
-            let join_row = ArticleJoinRow {
-                url: "https://example.com".to_string(),
-                title: "Test Article".to_string(),
-                pub_date: Utc.with_ymd_and_hms(2023, 12, 25, 10, 30, 0).unwrap(),
-                source: "RSS".to_string(),
-                timestamp: None,
-                status_code: None,
-                content: None,
-            };
-
-            let json = serde_json::to_string(&join_row).unwrap();
-            assert!(json.contains("\"url\":\"https://example.com\""));
-            assert!(json.contains("\"title\":\"Test Article\""));
-            assert!(json.contains("\"source\":\"RSS\""));
-            assert!(json.contains("\"timestamp\":null"));
-            assert!(json.contains("\"status_code\":null"));
-            assert!(json.contains("\"content\":null"));
         }
     }
 

--- a/src/core/article/model.rs
+++ b/src/core/article/model.rs
@@ -28,6 +28,8 @@ pub enum ArticleStatus {
 pub struct ArticleUrlStatus {
     pub url: String,
     pub status_code: Option<i32>,
+    // 記事の公開日時。再取得優先度の判断などに用いる（低レベル用途）
+    pub pub_date: DateTime<Utc>,
 }
 
 // ArticleLinkとArticleのJOIN結果をそのまま受け取るDB用の構造体
@@ -190,10 +192,15 @@ mod tests {
             let url_status = ArticleUrlStatus {
                 url: "https://example.com".to_string(),
                 status_code: Some(200),
+                pub_date: Utc.with_ymd_and_hms(2023, 12, 25, 10, 30, 0).unwrap(),
             };
 
             assert_eq!(url_status.url, "https://example.com");
             assert_eq!(url_status.status_code, Some(200));
+            assert_eq!(
+                url_status.pub_date,
+                Utc.with_ymd_and_hms(2023, 12, 25, 10, 30, 0).unwrap()
+            );
         }
 
         /// ArticleUrlStatusのシリアライゼーションテスト
@@ -203,11 +210,13 @@ mod tests {
             let url_status = ArticleUrlStatus {
                 url: "https://example.com".to_string(),
                 status_code: Some(404),
+                pub_date: Utc.with_ymd_and_hms(2023, 12, 31, 23, 59, 59).unwrap(),
             };
 
             let json = serde_json::to_string(&url_status).unwrap();
             assert!(json.contains("\"url\":\"https://example.com\""));
             assert!(json.contains("\"status_code\":404"));
+            assert!(json.contains("\"pub_date\":\"2023-12-31T23:59:59Z\""));
         }
 
         /// ArticleUrlStatusのNoneステータスコードテスト
@@ -217,11 +226,13 @@ mod tests {
             let url_status = ArticleUrlStatus {
                 url: "https://example.com".to_string(),
                 status_code: None,
+                pub_date: Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap(),
             };
 
             let json = serde_json::to_string(&url_status).unwrap();
             assert!(json.contains("\"url\":\"https://example.com\""));
             assert!(json.contains("\"status_code\":null"));
+            assert!(json.contains("\"pub_date\":\"2023-01-01T00:00:00Z\""));
         }
     }
 

--- a/src/core/article/query.rs
+++ b/src/core/article/query.rs
@@ -14,6 +14,8 @@ pub struct ArticleQuery {
 #[derive(Debug, Default)]
 pub struct ArticleUrlStatusQuery {
     pub url_pattern: Option<String>,
+    pub pub_date_from: Option<DateTime<Utc>>,
+    pub pub_date_to: Option<DateTime<Utc>>,
     pub statuses: Option<Vec<ArticleStatus>>,
     pub limit: Option<i64>,
 }
@@ -93,6 +95,8 @@ mod tests {
         fn test_article_url_status_query_default() {
             let query = ArticleUrlStatusQuery::default();
             assert!(query.url_pattern.is_none());
+            assert!(query.pub_date_from.is_none());
+            assert!(query.pub_date_to.is_none());
             assert!(query.statuses.is_none());
             assert!(query.limit.is_none());
         }
@@ -101,14 +105,20 @@ mod tests {
         /// 目的: 各フィールドが正常に設定されることを確認
         #[test]
         fn test_article_url_status_query_fields() {
+            let from_date = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+            let to_date = Utc.with_ymd_and_hms(2025, 1, 1, 23, 59, 59).unwrap();
             let statuses = vec![ArticleStatus::Success, ArticleStatus::Error(404)];
             let query = ArticleUrlStatusQuery {
                 url_pattern: Some("example.com".to_string()),
+                pub_date_from: Some(from_date),
+                pub_date_to: Some(to_date),
                 statuses: Some(statuses.clone()),
                 limit: Some(50),
             };
 
             assert_eq!(query.url_pattern, Some("example.com".to_string()));
+            assert_eq!(query.pub_date_from, Some(from_date));
+            assert_eq!(query.pub_date_to, Some(to_date));
             assert_eq!(query.statuses, Some(statuses));
             assert_eq!(query.limit, Some(50));
         }

--- a/src/core/article/query.rs
+++ b/src/core/article/query.rs
@@ -20,17 +20,6 @@ pub struct ArticleUrlStatusQuery {
     pub limit: Option<i64>,
 }
 
-// ArticleJoinRowを取得する際に使用するクエリモデル
-#[derive(Debug, Default)]
-pub(crate) struct ArticleJoinRowQuery {
-    pub link_pattern: Option<String>,
-    pub pub_date_from: Option<DateTime<Utc>>,
-    pub pub_date_to: Option<DateTime<Utc>>,
-    pub statuses: Option<Vec<ArticleStatus>>,
-    pub source: Option<String>,
-    pub limit: Option<i64>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -124,45 +113,5 @@ mod tests {
         }
     }
 
-    mod article_join_row_query {
-        use super::*;
-
-        /// ArticleJoinRowQueryのデフォルト値テスト
-        /// 目的: Default traitの正常な動作を確認
-        #[test]
-        fn test_article_join_row_query_default() {
-            let query = ArticleJoinRowQuery::default();
-            assert!(query.link_pattern.is_none());
-            assert!(query.pub_date_from.is_none());
-            assert!(query.pub_date_to.is_none());
-            assert!(query.statuses.is_none());
-            assert!(query.source.is_none());
-            assert!(query.limit.is_none());
-        }
-
-        /// ArticleJoinRowQueryの全フィールド設定テスト
-        /// 目的: 全てのフィールドが正常に設定されることを確認
-        #[test]
-        fn test_article_join_row_query_all_fields() {
-            let from_date = Utc.with_ymd_and_hms(2023, 6, 1, 0, 0, 0).unwrap();
-            let to_date = Utc.with_ymd_and_hms(2023, 6, 30, 23, 59, 59).unwrap();
-            let statuses = vec![ArticleStatus::Success];
-
-            let query = ArticleJoinRowQuery {
-                link_pattern: Some("news.com".to_string()),
-                pub_date_from: Some(from_date),
-                pub_date_to: Some(to_date),
-                statuses: Some(statuses.clone()),
-                source: Some("rss".to_string()),
-                limit: Some(200),
-            };
-
-            assert_eq!(query.link_pattern, Some("news.com".to_string()));
-            assert_eq!(query.pub_date_from, Some(from_date));
-            assert_eq!(query.pub_date_to, Some(to_date));
-            assert_eq!(query.statuses, Some(statuses));
-            assert_eq!(query.source, Some("rss".to_string()));
-            assert_eq!(query.limit, Some(200));
-        }
-    }
+    // ArticleJoinRowQuery は廃止
 }

--- a/src/core/article/search.rs
+++ b/src/core/article/search.rs
@@ -310,39 +310,30 @@ mod tests {
             Ok(())
         }
 
-        /// 目的: link_pattern・期間・limitの複合指定が正しく作用
-        /// 検証観点: 期間/パターン/limit のSQL適用をE2E確認
+        /// 目的: link_pattern・期間・limitの複合指定が正しく作用し、空文字contentの行も含まれる
+        /// 検証観点: 期間/パターン/limit のSQL適用に加え、空文字contentが返ること
         #[sqlx::test(fixtures("search"))]
         async fn test_pattern_date_limit(pool: PgPool) -> Result<(), anyhow::Error> {
             let q = ArticleQuery {
                 link_pattern: Some("another.com".to_string()),
                 pub_date_from: Some(ts("2025-02-01T00:00:00Z")),
                 pub_date_to: Some(ts("2025-02-01T23:59:59Z")),
-                // 注意: limitはJOIN前に適用されるため、ここでは指定しない
-                limit: None,
+                // LIMITは最終結果に対して適用される
+                limit: Some(2),
             };
             let results = search_articles(Some(q), &pool).await?;
-            assert!(!results.is_empty());
-            assert!(results
-                .iter()
-                .any(|a| a.url.contains("another.com/path/ok")));
-            Ok(())
-        }
+            // 2件（ok, empty）に限定される
+            assert_eq!(results.len(), 2);
+            let urls: Vec<_> = results.iter().map(|a| a.url.as_str()).collect();
+            assert!(urls.contains(&"https://another.com/path/ok"));
+            assert!(urls.contains(&"https://another.com/path/empty"));
 
-        /// 目的: 空文字contentのレコードも取得対象になること
-        /// 検証観点: スキーマ上NOT NULL（空文字はあり得る）であることを前提に、空文字を保持したまま返す
-        #[sqlx::test(fixtures("search"))]
-        async fn test_include_empty_content(pool: PgPool) -> Result<(), anyhow::Error> {
-            let results = search_articles(None, &pool).await?;
-            // 対象URLが含まれていること
-            let target = results
+            // 空文字contentの行が含まれること
+            let empty = results
                 .iter()
-                .find(|a| a.url == "https://another.com/path/empty");
-            assert!(target.is_some(), "空文字contentのURLが返ってくること");
-            assert!(
-                target.unwrap().content.is_empty(),
-                "contentは空文字であること"
-            );
+                .find(|a| a.url == "https://another.com/path/empty")
+                .expect("空文字contentのURLが含まれる");
+            assert!(empty.content.is_empty());
             Ok(())
         }
     }

--- a/src/core/article/search.rs
+++ b/src/core/article/search.rs
@@ -18,20 +18,24 @@ pub async fn search_article_url_statuses(
         FROM article_links AS l
         LEFT JOIN articles AS a ON l.url = a.url
         WHERE ($1::text IS NULL OR l.url ILIKE '%' || $1 || '%')
+          AND ($2::timestamptz IS NULL OR l.pub_date >= $2)
+          AND ($3::timestamptz IS NULL OR l.pub_date <= $3)
           AND (
-                NOT $2
+                NOT $4
              OR (
-                    (COALESCE($3::bool, false) AND a.status_code IS NULL)
-                 OR (COALESCE($4::bool, false) AND a.status_code = 200)
-                 OR ($5::int[] IS NOT NULL AND a.status_code = ANY($5))
+                    (COALESCE($5::bool, false) AND a.status_code IS NULL)
+                 OR (COALESCE($6::bool, false) AND a.status_code = 200)
+                 OR ($7::int[] IS NOT NULL AND a.status_code = ANY($7))
                 )
           )
         ORDER BY l.url ASC
-        LIMIT $6
+        LIMIT $8
     "#;
 
     let results = sqlx::query_as::<_, ArticleUrlStatus>(sql)
         .bind(query.url_pattern)
+        .bind(query.pub_date_from)
+        .bind(query.pub_date_to)
         .bind(apply_status)
         .bind(has_unprocessed)
         .bind(has_success)
@@ -279,6 +283,7 @@ mod tests {
                 url_pattern: None,
                 statuses: Some(vec![ArticleStatus::Unprocessed]),
                 limit: None,
+                ..Default::default()
             };
             let unprocessed = search_article_url_statuses(Some(q), &pool).await?;
             assert_eq!(unprocessed.len(), 1);
@@ -289,6 +294,7 @@ mod tests {
                 url_pattern: None,
                 statuses: Some(vec![ArticleStatus::Success]),
                 limit: None,
+                ..Default::default()
             };
             let success = search_article_url_statuses(Some(q), &pool).await?;
             assert_eq!(success.len(), 1);
@@ -299,6 +305,7 @@ mod tests {
                 url_pattern: None,
                 statuses: Some(vec![ArticleStatus::Error(404)]),
                 limit: None,
+                ..Default::default()
             };
             let not_found = search_article_url_statuses(Some(q), &pool).await?;
             assert_eq!(not_found.len(), 1);
@@ -314,6 +321,7 @@ mod tests {
                 url_pattern: Some("https://limit.test".to_string()),
                 statuses: None,
                 limit: Some(2),
+                ..Default::default()
             };
             let results = search_article_url_statuses(Some(q), &pool).await?;
             assert_eq!(results.len(), 2);
@@ -325,6 +333,24 @@ mod tests {
                     "https://limit.test/b".to_string(),
                 ]
             );
+            Ok(())
+        }
+
+        /// 目的: pub_date 範囲フィルタが包含(>=, <=)で効くこと
+        /// 検証観点: exact-start と exact-end を含み、before を除外する
+        #[sqlx::test(fixtures("search_pub_date_range"))]
+        async fn test_pub_date_range_filters(pool: PgPool) -> Result<(), anyhow::Error> {
+            let q = ArticleUrlStatusQuery {
+                url_pattern: Some("https://date.test".to_string()),
+                pub_date_from: Some(ts("2025-01-01T00:00:00Z")),
+                pub_date_to: Some(ts("2025-01-01T23:59:59Z")),
+                ..Default::default()
+            };
+            let results = search_article_url_statuses(Some(q), &pool).await?;
+            let urls = get_urls(&results, |x| &x.url);
+            assert!(urls.contains(&"https://date.test/exact-start".to_string()));
+            assert!(urls.contains(&"https://date.test/exact-end".to_string()));
+            assert!(!urls.contains(&"https://date.test/before".to_string()));
             Ok(())
         }
     }

--- a/src/core/article/search.rs
+++ b/src/core/article/search.rs
@@ -14,7 +14,7 @@ pub async fn search_article_url_statuses(
         normalize_statuses(query.statuses.as_deref());
 
     let sql = r#"
-        SELECT l.url, a.status_code
+        SELECT l.url, a.status_code, l.pub_date
         FROM article_links AS l
         LEFT JOIN articles AS a ON l.url = a.url
         WHERE ($1::text IS NULL OR l.url ILIKE '%' || $1 || '%')

--- a/src/core/article/search.rs
+++ b/src/core/article/search.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use sqlx::PgPool;
 
-use crate::core::article::model::{Article, ArticleJoinRow, ArticleStatus, ArticleUrlStatus};
-use crate::core::article::query::{ArticleJoinRowQuery, ArticleQuery, ArticleUrlStatusQuery};
+use crate::core::article::model::{Article, ArticleStatus, ArticleUrlStatus};
+use crate::core::article::query::{ArticleQuery, ArticleUrlStatusQuery};
 
 /// ArticleUrlStatusを取得する（読み取り）
 pub async fn search_article_url_statuses(
@@ -48,107 +48,39 @@ pub async fn search_article_url_statuses(
     Ok(results)
 }
 
-/// ドメイン向けArticleを取得（status_code=200のみ、結合行から変換）
+/// ドメイン向けArticleを取得（status_code=200のみを直接SQLで取得）
 pub async fn search_articles(query: Option<ArticleQuery>, pool: &PgPool) -> Result<Vec<Article>> {
     let query = query.unwrap_or_default();
 
-    // 低レベルのJOIN検索クエリに変換
-    let join_query = ArticleJoinRowQuery {
-        link_pattern: query.link_pattern,
-        pub_date_from: query.pub_date_from,
-        pub_date_to: query.pub_date_to,
-        statuses: Some(vec![ArticleStatus::Success]), // 成功したもののみ
-        source: None,
-        limit: query.limit,
-    };
-
-    let join_rows = search_article_join_rows(Some(join_query), pool).await?;
-
-    // ArticleJoinRowからArticleに変換
-    let mut dropped_count = 0;
-    let articles: Result<Vec<Article>, _> = join_rows
-        .into_iter()
-        .filter_map(|row| {
-            // contentが存在し、かつ空でないことを is_some_and で簡潔に表現
-            if row.status_code == Some(200)
-                && row.content.as_ref().is_some_and(|c| !c.is_empty())
-                && row.timestamp.is_some()
-            {
-                Some(Ok(Article {
-                    url: row.url,
-                    title: row.title,
-                    pub_date: row.pub_date,
-                    updated_at: row.timestamp.expect("フィルタ条件で確認済みのtimestampがNone"),
-                    content: row.content.expect("フィルタ条件で確認済みのcontentがNone"),
-                }))
-            } else {
-                dropped_count += 1;
-                if cfg!(debug_assertions) {
-                    eprintln!(
-                        "記事レコードをスキップ: url={}, status_code={:?}, content_exists={}, timestamp_exists={}",
-                        row.url,
-                        row.status_code,
-                        row.content.is_some(),
-                        row.timestamp.is_some()
-                    );
-                }
-                None
-            }
-        })
-        .collect();
-
-    if dropped_count > 0 {
-        println!("{}件の無効な記事レコードをスキップしました", dropped_count);
-    }
-
-    articles
-}
-
-/// ArticleJoinRowを取得する（読み取り）
-async fn search_article_join_rows(
-    query: Option<ArticleJoinRowQuery>,
-    pool: &PgPool,
-) -> Result<Vec<ArticleJoinRow>> {
-    let query = query.unwrap_or_default();
-    let (apply_status, has_unprocessed, has_success, error_codes) =
-        normalize_statuses(query.statuses.as_deref());
-
+    // ドメイン要件に合致する行だけをDB側で抽出
+    // - 成功(200)のみ（contentはスキーマ上NOT NULLのため追加条件は不要）
+    // - timestampは必須（updated_atとして受け取る）
     let sql = r#"
-        SELECT l.url, l.title, l.pub_date, l.source,
-               a.timestamp, a.status_code, a.content
+        SELECT l.url,
+               l.title,
+               l.pub_date,
+               a.timestamp AS updated_at,
+               a.content
         FROM article_links AS l
-        LEFT JOIN articles AS a ON l.url = a.url
+        JOIN articles AS a ON l.url = a.url
         WHERE ($1::text IS NULL OR l.url ILIKE '%' || $1 || '%')
           AND ($2::timestamptz IS NULL OR l.pub_date >= $2)
           AND ($3::timestamptz IS NULL OR l.pub_date <= $3)
-          AND (
-                NOT $4
-             OR (
-                    (COALESCE($5::bool, false) AND a.status_code IS NULL)
-                 OR (COALESCE($6::bool, false) AND a.status_code = 200)
-                 OR ($7::int[] IS NOT NULL AND a.status_code = ANY($7))
-                )
-          )
-          AND ($8::text IS NULL OR l.source = $8)
+          AND a.status_code = 200
         ORDER BY l.pub_date DESC
-        LIMIT $9
+        LIMIT $4
     "#;
 
-    let results = sqlx::query_as::<_, ArticleJoinRow>(sql)
+    let articles = sqlx::query_as::<_, Article>(sql)
         .bind(query.link_pattern)
         .bind(query.pub_date_from)
         .bind(query.pub_date_to)
-        .bind(apply_status)
-        .bind(has_unprocessed)
-        .bind(has_success)
-        .bind(error_codes)
-        .bind(query.source)
         .bind(query.limit)
         .fetch_all(pool)
         .await
-        .context("記事結合情報の取得に失敗")?;
+        .context("記事(成功のみ)の取得に失敗")?;
 
-    Ok(results)
+    Ok(articles)
 }
 
 // 内部実装：statuses指定の正規化（このモジュール内のみで使用する）
@@ -182,7 +114,7 @@ fn normalize_statuses(statuses: Option<&[ArticleStatus]>) -> (bool, bool, bool, 
 mod tests {
     use super::*;
     use crate::core::article::model::ArticleStatus;
-    use crate::core::article::query::{ArticleJoinRowQuery, ArticleQuery, ArticleUrlStatusQuery};
+    use crate::core::article::query::{ArticleQuery, ArticleUrlStatusQuery};
     use chrono::{DateTime, Utc};
     use sqlx::PgPool;
 
@@ -360,16 +292,15 @@ mod tests {
         use super::helper::*;
         use super::*;
 
-        /// 目的: 成功(200)かつcontent非空・timestamp有りのみが返ること
-        /// 検証観点: JOIN -> フィルタ -> Article変換 の一連の正当性
+        /// 目的: 成功(200)かつtimestamp有りの記事が返ること（contentは空文字も許容）
+        /// 検証観点: 直接SQLでの絞り込み（status=200）とマッピングの正当性
         #[sqlx::test(fixtures("search"))]
         async fn test_basic_filter_and_transform(pool: PgPool) -> Result<(), anyhow::Error> {
             let results = search_articles(None, &pool).await?;
             // search.sql には 200&content有り が3件以上含まれる前提
             assert!(results.len() >= 3);
 
-            // いずれもcontent非空・URL妥当性
-            assert!(results.iter().all(|a| !a.content.is_empty()));
+            // URL妥当性（代表例）
             assert!(results
                 .iter()
                 .any(|a| a.url.contains("example.com/article-1")));
@@ -379,19 +310,8 @@ mod tests {
             Ok(())
         }
 
-        /// 目的: 空文字contentは除外されること
-        /// 検証観点: content.is_empty() の除外ロジック
-        #[sqlx::test(fixtures("search_empty_content"))]
-        async fn test_drop_empty_content(pool: PgPool) -> Result<(), anyhow::Error> {
-            let results = search_articles(None, &pool).await?;
-            let urls = get_urls(&results, |x| &x.url);
-            assert!(urls.contains(&"https://empty.test/ok".to_string()));
-            assert!(!urls.contains(&"https://empty.test/empty".to_string()));
-            Ok(())
-        }
-
         /// 目的: link_pattern・期間・limitの複合指定が正しく作用
-        /// 検証観点: ArticleJoinRowQueryへの変換ロジック含め E2E 確認
+        /// 検証観点: 期間/パターン/limit のSQL適用をE2E確認
         #[sqlx::test(fixtures("search"))]
         async fn test_pattern_date_limit(pool: PgPool) -> Result<(), anyhow::Error> {
             let q = ArticleQuery {
@@ -403,73 +323,26 @@ mod tests {
             };
             let results = search_articles(Some(q), &pool).await?;
             assert!(!results.is_empty());
-            assert!(results[0].url.contains("another.com/path/ok"));
-            Ok(())
-        }
-    }
-
-    // DB使用テスト: search_article_join_rows（低レベルJOIN結果）
-    mod search_article_join_rows {
-        use super::helper::*;
-        use super::search_article_join_rows;
-        use super::*;
-
-        /// 目的: ステータス複合指定（Success + Error）で該当行のみ返る
-        /// 検証観点: normalize_statuses -> SQL条件のOR結合が正しく動作
-        #[sqlx::test(fixtures("search"))]
-        async fn test_status_mixed(pool: PgPool) -> Result<(), anyhow::Error> {
-            let q = ArticleJoinRowQuery {
-                link_pattern: None,
-                pub_date_from: None,
-                pub_date_to: None,
-                statuses: Some(vec![ArticleStatus::Success, ArticleStatus::Error(500)]),
-                source: None,
-                limit: None,
-            };
-            let rows = search_article_join_rows(Some(q), &pool).await?;
-            assert!(rows
+            assert!(results
                 .iter()
-                .all(|r| r.status_code == Some(200) || r.status_code == Some(500)));
-            assert!(rows.iter().any(|r| r.status_code == Some(200)));
-            assert!(rows.iter().any(|r| r.status_code == Some(500)));
+                .any(|a| a.url.contains("another.com/path/ok")));
             Ok(())
         }
 
-        /// 目的: sourceフィルタで特定ソースのみ抽出できる
-        /// 検証観点: l.source = $8 の等価フィルタ
-        #[sqlx::test(fixtures("search_source_filter"))]
-        async fn test_source_filter(pool: PgPool) -> Result<(), anyhow::Error> {
-            let q = ArticleJoinRowQuery {
-                link_pattern: None,
-                pub_date_from: None,
-                pub_date_to: None,
-                statuses: Some(vec![ArticleStatus::Success]),
-                source: Some("rss".to_string()),
-                limit: None,
-            };
-            let rows = search_article_join_rows(Some(q), &pool).await?;
-            assert!(!rows.is_empty());
-            assert!(rows.iter().all(|r| r.source == "rss"));
-            Ok(())
-        }
-
-        /// 目的: 期間境界が含まれる（>=, <=）ことを確認
-        /// 検証観点: pub_date_from/toのinclusive動作
-        #[sqlx::test(fixtures("search_pub_date_range"))]
-        async fn test_date_range_inclusive(pool: PgPool) -> Result<(), anyhow::Error> {
-            let q = ArticleJoinRowQuery {
-                link_pattern: None,
-                pub_date_from: Some(ts("2025-01-01T00:00:00Z")),
-                pub_date_to: Some(ts("2025-01-01T23:59:59Z")),
-                statuses: Some(vec![ArticleStatus::Success]),
-                source: None,
-                limit: None,
-            };
-            let rows = search_article_join_rows(Some(q), &pool).await?;
-            let urls = get_urls(&rows, |x| &x.url);
-            assert!(urls.contains(&"https://date.test/exact-start".to_string()));
-            assert!(urls.contains(&"https://date.test/exact-end".to_string()));
-            assert!(!urls.contains(&"https://date.test/before".to_string()));
+        /// 目的: 空文字contentのレコードも取得対象になること
+        /// 検証観点: スキーマ上NOT NULL（空文字はあり得る）であることを前提に、空文字を保持したまま返す
+        #[sqlx::test(fixtures("search"))]
+        async fn test_include_empty_content(pool: PgPool) -> Result<(), anyhow::Error> {
+            let results = search_articles(None, &pool).await?;
+            // 対象URLが含まれていること
+            let target = results
+                .iter()
+                .find(|a| a.url == "https://another.com/path/empty");
+            assert!(target.is_some(), "空文字contentのURLが返ってくること");
+            assert!(
+                target.unwrap().content.is_empty(),
+                "contentは空文字であること"
+            );
             Ok(())
         }
     }


### PR DESCRIPTION
Articleを取得する際にはsql側で先に絞り込めばいい。
ArticleJoinRowをrust側でフィルタリングする利点が現状では想定されない。